### PR TITLE
Implement Supabase auth boot improvements

### DIFF
--- a/js/supa.js
+++ b/js/supa.js
@@ -1,29 +1,51 @@
-// js/supa.js (ESM)
-// Stable API surface for LinkGo frontend against Supabase JS v2.
-// Import via ESM (no bundler).
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.47.10/+esm';
+// js/supa.js
+// Antag ESM i browser. Se till att @supabase/supabase-js är inkluderad i projektet via CDN eller bundlat.
+// Om ni kör CDN, lägg <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script> i <head> på sidorna.
+// Om ni redan har klienten – behåll men ersätt init-delen med denna defensiva.
 
-// --- Config ---
-const CFG = {
-  SUPABASE_URL: 'https://wupbylrjorizbudxfktl.supabase.co',
-  SUPABASE_ANON_KEY: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Ind1cGJ5bHJqb3JpemJ1ZHhma3RsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTcyNjExMDksImV4cCI6MjA3MjgzNzEwOX0.tQAfScNXAC0s4N8Qf8gFpWtO5lFLHiPzE57Qf8kvzJc'
-};
+const cfg = (window.CONFIG || {});
+const SB_URL = cfg.SUPABASE_URL;
+const SB_ANON = cfg.SUPABASE_ANON_KEY;
 
-// --- Client ---
-const supabase = createClient(CFG.SUPABASE_URL, CFG.SUPABASE_ANON_KEY);
+if (!SB_URL || !SB_ANON) {
+  console.error('[AuthBoot] Missing SUPABASE_URL or SUPABASE_ANON_KEY in window.CONFIG', window.CONFIG);
+  throw new Error('Supabase config saknas. Fyll i SUPABASE_URL och SUPABASE_ANON_KEY i public/config.js');
+}
+
+// globalThis.supabase kan redan finnas om ni initierat via CDN. Skapa om inte.
+let supabaseClient = globalThis.supabase?.createClient
+  ? globalThis.supabase.createClient(SB_URL, SB_ANON)
+  : (typeof createClient === 'function'
+      ? createClient(SB_URL, SB_ANON) // om createClient ligger globalt
+      : null);
+
+if (!supabaseClient) {
+  console.error('[AuthBoot] Supabase client kunde inte skapas. Har du laddat in supabase-js?');
+  throw new Error('Saknar Supabase-klient. Lägg in supabase-js via CDN eller bundling.');
+}
+
+async function healthCheck() {
+  try {
+    const { data, error } = await supabaseClient.auth.getSession();
+    if (error) throw error;
+    return { ok: true, session: data.session || null };
+  } catch (e) {
+    return { ok: false, error: String(e && e.message || e) };
+  }
+}
 
 const Auth = {
   async getSession() {
-    const { data, error } = await supabase.auth.getSession();
+    const { data, error } = await supabaseClient.auth.getSession();
     if (error) throw error;
     return { session: data.session, user: data.session?.user || null };
   },
   async signInWithPassword({ email, password }) {
-    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    const { data, error } = await supabaseClient.auth.signInWithPassword({ email, password });
     return { session: data?.session || null, user: data?.user || null, error };
   },
   async signUpWithEmail({ email, password, data }) {
-    const { data: res, error } = await supabase.auth.signUp({
+    const { data: res, error } = await supabaseClient.auth.signUp({
       email, password, options: { data }
     });
     const session = res?.session || null;
@@ -32,29 +54,27 @@ const Auth = {
     return { user, session, error, needsConfirmation };
   },
   async signOut() {
-    const { error } = await supabase.auth.signOut();
+    const { error } = await supabaseClient.auth.signOut();
     if (error) throw error;
   },
-  redirectToHome() { location.href = './home.html'; },
   async requireSession() {
     const { session } = await this.getSession();
     if (!session) location.href = './login.html';
-  }
+  },
+  redirectToHome() { location.href = './home.html'; },
+  healthCheck,
 };
 
 const Profiles = {
   async getMyProfile() {
-    const { data: sessionData } = await supabase.auth.getSession();
+    const { data: sessionData } = await supabaseClient.auth.getSession();
     const uid = sessionData?.session?.user?.id;
     if (!uid) return null;
-    const { data, error } = await supabase
-      .from('profiles')
-      .select('*')
-      .eq('id', uid)
-      .single();
+    const { data, error } = await supabaseClient.from('profiles').select('*').eq('id', uid).single();
     if (error) throw error;
     return data;
   }
 };
 
-export default { Auth, Profiles };
+const supa = { Auth, Profiles };
+export default supa;

--- a/public/config.js
+++ b/public/config.js
@@ -1,9 +1,10 @@
-/**
- * Global config for building absolute URLs consistently.
- * SITE_URL defaults to window.location.origin at runtime.
- */
+// public/config.js
 window.CONFIG = {
-  SITE_URL: window.CONFIG?.SITE_URL || 'http://localhost:5500',
+  // ⚠️ FYLL I DINA RIKTIGA PRODVÄRDEN ELLER DEV-VÄRDEN
+  SUPABASE_URL: window.CONFIG?.SUPABASE_URL || 'https://wupbylrjorizbudxfktl.supabase.co',
+  SUPABASE_ANON_KEY: window.CONFIG?.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Ind1cGJ5bHJqb3JpemJ1ZHhma3RsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTcyNjExMDksImV4cCI6MjA3MjgzNzEwOX0.tQAfScNXAC0s4N8Qf8gFpWtO5lFLHiPzE57Qf8kvzJc',
+
+  SITE_URL: window.CONFIG?.SITE_URL || (location.origin || 'http://localhost:5500'),
   DEBUG: true,
-  ...window.CONFIG
+  ...window.CONFIG,
 };

--- a/public/login.html
+++ b/public/login.html
@@ -6,6 +6,7 @@
   <title>Logga in – LinkGo</title>
   <link rel="stylesheet" href="./tokens.css" />
   <script src="./config.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <style>
     body {
       margin: 0;
@@ -134,21 +135,38 @@
       </form>
     </div>
   </div>
+  <div id="debug" style="font:12px/1.2 system-ui; background:#f3f4f6; padding:8px; border-radius:6px; margin-top:8px; display:none"></div>
 
   <script type="module">
 import supa from '../js/supa.js';
 const $ = (sel, root=document) => root.querySelector(sel);
+const msg = $('#msg') || (() => { const p = document.createElement('p'); p.id='msg'; p.style.marginTop='8px'; (document.querySelector('form')||document.body).appendChild(p); return p; })();
+const setMsg = (t,c='') => { msg.textContent = t || ''; msg.className = c; };
 
-// Diskret statusfält om det saknas
-let msg = document.getElementById('msg');
-if (!msg) {
-  msg = document.createElement('p');
-  msg.id = 'msg';
-  msg.style.marginTop = '8px';
-  msg.style.minHeight = '1.2em';
-  (document.querySelector('form') || document.body).appendChild(msg);
+const dbg = $('#debug');
+if (window.CONFIG?.DEBUG) dbg.style.display = 'block';
+
+function renderDebug(extra={}) {
+  if (!dbg) return;
+  const safeKey = (k) => k ? (k.slice(0,8)+'…'+k.slice(-4)) : '';
+  dbg.innerHTML = `
+    <div><strong>origin:</strong> ${location.origin}</div>
+    <div><strong>cfg.url:</strong> ${window.CONFIG?.SUPABASE_URL||'❌'}</div>
+    <div><strong>cfg.key:</strong> ${window.CONFIG?.SUPABASE_ANON_KEY ? 'set ('+safeKey(window.CONFIG.SUPABASE_ANON_KEY)+')' : '❌'}</div>
+    <div><strong>health:</strong> ${extra.health || '-'}</div>
+    <div><strong>session:</strong> ${extra.session ? '✅' : '–'}</div>
+  `;
 }
-const setMsg = (t, cls='') => { msg.textContent = t || ''; msg.className = cls; };
+
+(async () => {
+  try {
+    const hc = await supa.Auth.healthCheck();
+    renderDebug({ health: hc.ok ? 'ok' : ('fail: ' + (hc.error||'')), session: hc.session });
+  } catch (e) {
+    console.error('healthCheck error', e);
+    renderDebug({ health: 'exception' });
+  }
+})();
 
 const form = document.querySelector('form') || document;
 const emailEl = $('#email', form);
@@ -156,7 +174,7 @@ const passEl  = $('#password', form);
 const btn     = $('#btn-login', form) || form.querySelector('button[type="submit"]') || form.querySelector('button');
 
 const onSubmit = async (e) => {
-  if (e) e.preventDefault(); // ingen sidladdning => inputs behålls
+  if (e) e.preventDefault();
   if (btn) btn.disabled = true;
   setMsg('Loggar in…','info');
   const email = emailEl?.value?.trim();
@@ -168,7 +186,7 @@ const onSubmit = async (e) => {
       if (code === 'invalid_credentials') setMsg('Fel e-post eller lösenord.','error');
       else if (/confirm|verified|not[_\s-]*confirmed/i.test(error.message)) setMsg('Bekräfta din e-post via länken vi skickat.','error');
       else setMsg(error.message || 'Kunde inte logga in.','error');
-      return; // behåll inmatningar
+      return;
     }
     if (session) { supa.Auth.redirectToHome(); return; }
     setMsg('Oväntat läge – prova igen.','error');

--- a/public/signup.html
+++ b/public/signup.html
@@ -6,6 +6,7 @@
   <title>Skapa konto – LinkGo</title>
   <link rel="stylesheet" href="./tokens.css" />
   <script src="./config.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <style>
     body {
       margin: 0;
@@ -127,21 +128,28 @@
       </form>
     </div>
   </div>
+  <div id="debug" style="font:12px/1.2 system-ui; background:#f3f4f6; padding:8px; border-radius:6px; margin-top:8px; display:none"></div>
 
   <script type="module">
 import supa from '../js/supa.js';
 const $ = (sel, root=document) => root.querySelector(sel);
+const msg = $('#msg') || (() => { const p = document.createElement('p'); p.id='msg'; p.style.marginTop='8px'; (document.querySelector('form')||document.body).appendChild(p); return p; })();
+const setMsg = (t,c='') => { msg.textContent = t || ''; msg.className = c; };
 
-// Diskret statusfält om det saknas
-let msg = document.getElementById('msg');
-if (!msg) {
-  msg = document.createElement('p');
-  msg.id = 'msg';
-  msg.style.marginTop = '8px';
-  msg.style.minHeight = '1.2em';
-  (document.querySelector('form') || document.body).appendChild(msg);
+const dbg = $('#debug');
+if (window.CONFIG?.DEBUG) dbg.style.display = 'block';
+function renderDebug(extra={}) {
+  if (!dbg) return;
+  const safeKey = (k) => k ? (k.slice(0,8)+'…'+k.slice(-4)) : '';
+  dbg.innerHTML = `
+    <div><strong>origin:</strong> ${location.origin}</div>
+    <div><strong>cfg.url:</strong> ${window.CONFIG?.SUPABASE_URL||'❌'}</div>
+    <div><strong>cfg.key:</strong> ${window.CONFIG?.SUPABASE_ANON_KEY ? 'set ('+safeKey(window.CONFIG.SUPABASE_ANON_KEY)+')' : '❌'}</div>
+    <div><strong>note:</strong> signUp visar “bekräfta e-post” om session ej sätts och error saknas.</div>
+  `;
 }
-const setMsg = (t, cls='') => { msg.textContent = t || ''; msg.className = cls; };
+
+renderDebug();
 
 const form = document.querySelector('form') || document;
 const emailEl = $('#email', form);
@@ -150,7 +158,7 @@ const nameEl  = $('#full_name', form);
 const btn     = $('#btn-signup', form) || form.querySelector('button[type="submit"]') || form.querySelector('button');
 
 const onSubmit = async (e) => {
-  if (e) e.preventDefault(); // ingen sidladdning => inputs behålls
+  if (e) e.preventDefault();
   if (btn) btn.disabled = true;
   setMsg('Skapar konto…','info');
   const email = emailEl?.value?.trim();
@@ -159,23 +167,18 @@ const onSubmit = async (e) => {
 
   try {
     const res = await supa.Auth.signUpWithEmail({ email, password, data: { full_name } });
-
-    // Konto finns redan → försök logga in
     if (res?.error?.code === 'user_already_registered' || /already/i.test(res?.error?.message||'')) {
       const { session, error: loginErr } = await supa.Auth.signInWithPassword({ email, password });
       if (!loginErr && session) { supa.Auth.redirectToHome(); return; }
       setMsg('Kontot finns redan men lösenordet matchar inte. Prova att logga in eller återställ lösenordet.','error');
       return;
     }
-
     if (res.needsConfirmation) {
       setMsg(`Vi har skickat ett bekräftelsemail till ${email}. Bekräfta och logga in.`,'ok');
-      return; // stanna kvar, inputs behålls
+      return;
     }
-
     if (res.session) { supa.Auth.redirectToHome(); return; }
     setMsg('Oväntat läge – prova att logga in.','error');
-
   } catch (err) {
     console.error(err); setMsg('Tekniskt fel vid registrering.','error');
   } finally {


### PR DESCRIPTION
## Summary
- move Supabase URL/key configuration into public/config.js with DEBUG enabled
- harden Supabase client bootstrap with defensive checks and health monitoring helpers
- enhance login and signup pages with CDN Supabase loader, debug panel, and resilient auth handlers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdb83fa2508320bde9e1b430668b9f